### PR TITLE
Add Lua535-beef

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 - [Raylib-beef](https://github.com/M0n7y5/raylib-beef) - A raylib binding for Beef programming language.
 - [Tilengine-beef](https://github.com/rootbeerking/Tilengine-Beef) - Beef Language wrapper for Tilengine 2D Graphics Engine.
 
+## Scripting engine
+*Awesome scripting libraries*
+
+- [Lua535-beef](https://github.com/thibmo/lua535-beef) - BeefLang wrapper library for Lua 5.3.5.
+
 ---
 
 # Contributing


### PR DESCRIPTION
Lua535-beef is awesome because it proves that Beef can handle working with scripting engines, allowing developers to provide their users with a scripting API.