### PR TITLE
Add json

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ An unofficial LSP server which works with any LSP-compatible editor and a Visual
 - [Atma.Json](https://github.com/xposure/Atma.Json) - Json serialization framework.
 - [Beef-toml](https://github.com/killamaaki/beef-toml) - Toml parser/serializer library.
 - [bon](https://github.com/EinScott/bon) - A reflection based structure serialization library designed for Beef.
+- [json](https://github.com/EinScott/json) - A light arbitrary JSON tree read and write library.
 - [Xml-Beef](https://github.com/thibmo/Xml-Beef) - Single-file XML parser in Beef with doctype support.
 
 ## Themes


### PR DESCRIPTION
json is a small library intended for fast reading and writing of standard json trees. In that way it is like JSON_Beef was, so we now have a lib to fill that gap.
I have not stress tested this extensively, but there are tests to ensure the basics work and it should be pretty fast going by how it works. Feel free to check it out. It's small so anyone should be able to read it in no time.
The name is a bit simple but all the other obvious names are already kind of gone... I hope this isn't an issue.