### PR TITLE
Add FFmpeg-Beef

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
     - [IoC](#ioc)
     - [Image](#image)
     - [Logging](#logging)
+    - [Multimedia](#multimedia)
     - [Networking](#networking)
     - [Scripting Engines](#scripting-engines)
     - [Serialization](#serialization)
@@ -138,6 +139,11 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 *Logging libraries and frameworks.*
 
 - [Steak.Logging](https://github.com/RogueMacro/Steak.Logging) - An awesome logging library for Beef.
+
+## Multimedia
+*Multimedia related libraries.*
+
+- [FFmpeg-Beef](https://github.com/disarray2077/FFmpeg-Beef) - FFmpeg bindings for BeefLang.
 
 ## Networking
 *Networking related libraries*


### PR DESCRIPTION
This PR adds FFmpeg-Beef, a library that provides FFmpeg bindings for Beef. FFmpeg is the leading multimedia framework, able to decode, encode, transcode, mux, demux, stream, filter and play pretty much anything that humans and machines have created.